### PR TITLE
feature: dm-51 streamline templates and website files in s3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,7 @@ terraform/python
 terraform/output
 
 *.pem
+
+# Golang executable
+src/staticgen/staticgen
+src/staticgen/staticgen.exe

--- a/src/staticgen/aws/download.go
+++ b/src/staticgen/aws/download.go
@@ -17,8 +17,8 @@ import (
 // Downloader for s3 bucket
 type Downloader struct {
 	*s3manager.Downloader
-	bucket, dir string
-	writer      http.ResponseWriter
+	bucket, dir, category string
+	writer                http.ResponseWriter
 }
 
 // FakeWriterAt fakes AWS NewWriter Struct

--- a/src/staticgen/controllers.go
+++ b/src/staticgen/controllers.go
@@ -12,8 +12,8 @@ import (
 // Set S3 bucket URL
 var bucket = os.Getenv("TEMPLATE_BUCKET")
 
-// WebsiteHandler generates static websites from templates
-func WebsiteHandler(w http.ResponseWriter, r *http.Request) {
+// GenerateHandler generates website files from template files in s3
+func GenerateHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	query := r.URL.Query()
@@ -26,13 +26,6 @@ func WebsiteHandler(w http.ResponseWriter, r *http.Request) {
 		decoder := json.NewDecoder(r.Body)
 		decoder.Decode(&context)
 		route.Generate(&context)
-	} else if r.Method == "GET" {
-		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.zip\"", "Website"))
-		route.Download(w)
-	} else if r.Method == "DELETE" {
-		route.Delete()
-	} else {
-		http.Error(w, "Invalid request method", http.StatusMethodNotAllowed)
 	}
 }
 
@@ -52,6 +45,33 @@ func TemplateHandler(w http.ResponseWriter, r *http.Request) {
 	} else if r.Method == "GET" {
 		w.Header().Set("Content-Type", "application/zip")
 		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.zip\"", category))
+		route.Download(w)
+	} else if r.Method == "DELETE" {
+		route.Delete()
+	} else {
+		http.Error(w, "Invalid request method", http.StatusMethodNotAllowed)
+	}
+}
+
+// WebsiteHandler generates static websites from templates
+func WebsiteHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	query := r.URL.Query()
+	category := query.Get("category")
+	domain := query.Get("domain")
+
+	route := aws.Route{Bucket: bucket, Category: category, Dir: domain}
+	if r.Method == "POST" {
+		// Recieve and unzip file
+		foldername, err := Receive(r, category)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		// Upload to S3
+		route.Upload(foldername)
+	} else if r.Method == "GET" {
+		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.zip\"", "Website"))
 		route.Download(w)
 	} else if r.Method == "DELETE" {
 		route.Delete()

--- a/src/staticgen/main.go
+++ b/src/staticgen/main.go
@@ -7,8 +7,9 @@ import (
 
 func main() {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/website/", WebsiteHandler)
+	mux.HandleFunc("/generate/", GenerateHandler)
 	mux.HandleFunc("/template/", TemplateHandler)
+	mux.HandleFunc("/website/", WebsiteHandler)
 
 	log.Println("listening on port 8000")
 	log.Fatal(http.ListenAndServe(":8000", mux))

--- a/src/staticgen/utils.go
+++ b/src/staticgen/utils.go
@@ -26,6 +26,11 @@ func Receive(reader *http.Request, category string) (string, error) {
 	}
 
 	defer file.Close()
+
+	// create tmp folder if it doesn't exist
+	if _, err := os.Stat("tmp"); os.IsNotExist(err) {
+		os.Mkdir("tmp", 0775)
+	}
 	tempFile, err := ioutil.TempFile("tmp", "upload-*.zip")
 	if err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
Created a new endpoint for generating template files into static files between s3 bucket prefixes. 
Added method for direct upload of static files in addition to uploading templates

## 💭 Description

<!--- Describe changes in detail -->

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [X] My code follows the code style of this project.
- [X] My changes have been adequately tested locally.
- [X] All automated tests are passing.
- [X] I have updated/added required automated tests.
- [X] Pre-commit checks are passing.

## 😪 Anything Else

<!--- Put anything else here that may be important -->
