### PR TITLE
feature: dm-64 add launch site endpoints

### DIFF
--- a/src/api/views/websites.py
+++ b/src/api/views/websites.py
@@ -148,12 +148,14 @@ class WebsiteLaunchView(MethodView):
     def get(self, website_id):
         """Launch a static site."""
         website = website_manager.get(document_id=website_id)
-        launch_site(website)
+        resp = launch_site(website)
+        return resp
 
     def delete(self, website_id):
         """Stop a static site."""
         website = website_manager.get(document_id=website_id)
-        delete_site(website)
+        resp = delete_site(website)
+        return resp
 
 
 def usage_history(website):

--- a/src/api/views/websites.py
+++ b/src/api/views/websites.py
@@ -11,6 +11,7 @@ import requests
 # cisagov Libraries
 from api.manager import ApplicationManager, WebsiteManager
 from settings import STATIC_GEN_URL, TEMPLATE_BUCKET
+from utils.aws.site_handler import delete_site, launch_site
 
 website_manager = WebsiteManager()
 application_manager = ApplicationManager()
@@ -139,6 +140,20 @@ class WebsiteGenerateView(MethodView):
                 "message": f"{domain} static site has been created from the {category} template."
             }
         )
+
+
+class WebsiteLaunchView(MethodView):
+    """Launch or stop an existing static site by adding dns records to its domain."""
+
+    def get(self, website_id):
+        """Launch a static site."""
+        website = website_manager.get(document_id=website_id)
+        launch_site(website)
+
+    def delete(self, website_id):
+        """Stop a static site."""
+        website = website_manager.get(document_id=website_id)
+        delete_site(website)
 
 
 def usage_history(website):

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,13 @@ from api.views.email_address import EmailAddressView
 from api.views.hosted_zones import HostedZonesView
 from api.views.proxies import ProxiesView, ProxyView
 from api.views.templates import TemplatesView, TemplateView
-from api.views.websites import WebsiteGenerateView, WebsitesView, WebsiteView
+from api.views.websites import (
+    WebsiteGenerateView,
+    WebsiteLaunchView,
+    WebsiteStopView,
+    WebsitesView,
+    WebsiteView,
+)
 from utils.decorators.auth import auth_required
 
 app = Flask(__name__)
@@ -34,6 +40,8 @@ rules = [
     ("/websites/", WebsitesView),
     ("/website/<website_id>/", WebsiteView),
     ("/website/<website_id>/generate/", WebsiteGenerateView),
+    ("/website/<website_id>/launch/", WebsiteLaunchView),
+    ("/website/<website_id>/stop/", WebsiteStopView),
 ]
 
 for rule in rules:

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,6 @@ from api.views.templates import TemplatesView, TemplateView
 from api.views.websites import (
     WebsiteGenerateView,
     WebsiteLaunchView,
-    WebsiteStopView,
     WebsitesView,
     WebsiteView,
 )
@@ -41,7 +40,6 @@ rules = [
     ("/website/<website_id>/", WebsiteView),
     ("/website/<website_id>/generate/", WebsiteGenerateView),
     ("/website/<website_id>/launch/", WebsiteLaunchView),
-    ("/website/<website_id>/stop/", WebsiteStopView),
 ]
 
 for rule in rules:

--- a/src/utils/aws/site_handler.py
+++ b/src/utils/aws/site_handler.py
@@ -6,10 +6,9 @@ import time
 
 # Third-Party Libraries
 import boto3
-import requests
 
 # cisagov Libraries
-from settings import AWS_REGION, STATIC_GEN_URL
+from settings import AWS_REGION
 
 logger = logging.getLogger(__name__)
 
@@ -17,18 +16,6 @@ logger = logging.getLogger(__name__)
 acm = boto3.client("acm")
 cloudfront = boto3.client("cloudfront")
 route53 = boto3.client("route53")
-
-
-def upload_template(category):
-    """Upload template files."""
-    resp = requests.post(f"{STATIC_GEN_URL}/template/?category={category}")
-    return {"message": resp.status_code}
-
-
-def delete_template(category):
-    """Delete template files."""
-    resp = requests.delete(f"{STATIC_GEN_URL}/template/?category={category}")
-    return {"message": resp.status_code}
 
 
 def launch_site(website):


### PR DESCRIPTION
add endpoints to launch and stop existing s3 sites

## 💭 Description
launching and stopping s3 sites are dictated by creating and removing DNS records from s3. save website state to db

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [ ] My code follows the code style of this project.
- [ ] My changes have been adequately tested locally.
- [ ] All automated tests are passing.
- [ ] I have updated/added required automated tests.
- [ ] Pre-commit checks are passing.

## 😪 Anything Else

<!--- Put anything else here that may be important -->
