### PR TITLE
use application_id instead of application

### DIFF
--- a/src/api/schemas/website_schema.py
+++ b/src/api/schemas/website_schema.py
@@ -47,7 +47,7 @@ class WebsiteSchema(Schema):
     category = fields.Str()
     s3_url = fields.Str()
     ip_address = fields.Str()
-    application = fields.Nested(application_schema.ApplicationSchema)
+    application_id = fields.Str()
     is_active = fields.Boolean()
     is_category_submitted = fields.List(fields.Nested(IsCategorySubmitted))
     is_email_active = fields.Boolean()

--- a/src/api/views/websites.py
+++ b/src/api/views/websites.py
@@ -92,7 +92,13 @@ class WebsiteView(MethodView):
             )
             website["application_id"] = application["_id"]
             # Save application to history
-            website["history"] = usage_history(website, application=application)
+            website["history"] = website.get("history", [])
+            website["history"].append(
+                {
+                    "application": application,
+                    "launch_date": datetime.utcnow(),
+                }
+            )
 
         return jsonify(website_manager.update(document_id=website_id, data=website))
 
@@ -239,17 +245,3 @@ class WebsiteLaunchView(MethodView):
             },
         )
         return resp
-
-
-def usage_history(website, application=None, template=None):
-    """Update website usage history on application change."""
-    update = {
-        "application": application,
-        "launch_date": datetime.utcnow(),
-    }
-    response = website.get("history")
-    if response:
-        response.append(update)
-    else:
-        response = [update]
-    return response


### PR DESCRIPTION
# <!--- Provide JIRA issue and general summary in title above. -->

## 💭 Description

<!--- Describe changes in detail -->

Revert template history.
Utilize application_id on website collection instead of duplicate application record.

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [ ] My code follows the code style of this project.
- [ ] My changes have been adequately tested locally.
- [ ] All automated tests are passing.
- [ ] I have updated/added required automated tests.
- [ ] Pre-commit checks are passing.

## 😪 Anything Else

<!--- Put anything else here that may be important -->
