### PR TITLE
feature: DM-108 add preview site to templates

### DIFF
--- a/src/staticgen/aws/parse.go
+++ b/src/staticgen/aws/parse.go
@@ -32,7 +32,16 @@ func (r *Route) Generate(ctx *Context, bucket string) {
 	uploader := s3manager.NewUploader(session.New())
 	for path := range walker {
 		if !strings.Contains(path, "base.html") {
-			rel, err := filepath.Rel("tmp/"+r.Category+"/", path)
+
+			// set tmp folder prefix
+			var tmpPrefix string
+			if bucket == WebsiteBucket {
+				tmpPrefix = strings.Join([]string{r.Category, "template"}, "/")
+			} else {
+				tmpPrefix = r.Category
+			}
+			rel, err := filepath.Rel("tmp/"+tmpPrefix+"/", path)
+
 			if err != nil {
 				log.Println("Unable to get relative path:", path, err)
 			}

--- a/src/staticgen/aws/parse.go
+++ b/src/staticgen/aws/parse.go
@@ -61,7 +61,7 @@ func (r *Route) Generate(ctx *Context) {
 
 			uploadKey := strings.Replace(strings.Join([]string{r.Dir, rel}, "/"), "\\", "/", -1)
 			_, err = uploader.Upload(&s3manager.UploadInput{
-				Bucket:      &r.WebsiteBucket,
+				Bucket:      &WebsiteBucket,
 				ContentType: &contenttype,
 				Key:         aws.String(uploadKey),
 				Body:        file,
@@ -70,7 +70,7 @@ func (r *Route) Generate(ctx *Context) {
 				log.Println("Failed to upload", path, err)
 			}
 
-			fmt.Printf("successfully uploaded %s/%s\n", r.WebsiteBucket, uploadKey)
+			fmt.Printf("successfully uploaded %s/%s\n", WebsiteBucket, uploadKey)
 		}
 	}
 	// Remove local temp files
@@ -104,9 +104,9 @@ func (r *Route) FileDownload() {
 	manager := s3manager.NewDownloader(session.New())
 
 	directory := filepath.Join("tmp/", r.Category)
-	d := Downloader{bucket: r.TemplateBucket, dir: directory, Downloader: manager}
+	d := Downloader{bucket: TemplateBucket, dir: directory, Downloader: manager}
 	client := s3.New(session.New())
-	params := &s3.ListObjectsInput{Bucket: &r.TemplateBucket, Prefix: &r.Category}
+	params := &s3.ListObjectsInput{Bucket: &TemplateBucket, Prefix: &r.Category}
 	client.ListObjectsPages(params, d.eachPage)
 }
 

--- a/src/staticgen/aws/parse.go
+++ b/src/staticgen/aws/parse.go
@@ -17,12 +17,12 @@ import (
 )
 
 // Generate static files and upload static to s3 bucket
-func (r *Route) Generate(ctx *Context, bucket string) {
+func (r *Route) Generate(ctx *Context, bucket, foldername string) {
 	// Gather the files to upload by walking the path recursively
 	walker := make(fileWalk)
 	// Run concurrently
 	go func() {
-		if err := filepath.Walk("tmp/"+r.Category+"/", walker.Walk); err != nil {
+		if err := filepath.Walk(strings.Join([]string{"tmp", r.Category, foldername}, "/"), walker.Walk); err != nil {
 			log.Println("Walk failed:", err)
 		}
 		close(walker)
@@ -34,14 +34,7 @@ func (r *Route) Generate(ctx *Context, bucket string) {
 		if !strings.Contains(path, "base.html") {
 
 			// set tmp folder prefix
-			var tmpPrefix string
-			if bucket == WebsiteBucket {
-				tmpPrefix = strings.Join([]string{r.Category, "template"}, "/")
-			} else {
-				tmpPrefix = r.Category
-			}
-			rel, err := filepath.Rel("tmp/"+tmpPrefix+"/", path)
-
+			rel, err := filepath.Rel(strings.Join([]string{"tmp", r.Category, foldername}, "/"), path)
 			if err != nil {
 				log.Println("Unable to get relative path:", path, err)
 			}

--- a/src/staticgen/aws/parse.go
+++ b/src/staticgen/aws/parse.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Generate static files and upload static to s3 bucket
-func (r *Route) Generate(ctx *Context) {
+func (r *Route) Generate(ctx *Context, bucket string) {
 	// Gather the files to upload by walking the path recursively
 	walker := make(fileWalk)
 	// Run concurrently
@@ -59,9 +59,16 @@ func (r *Route) Generate(ctx *Context) {
 				}
 			}
 
-			uploadKey := strings.Replace(strings.Join([]string{r.Dir, rel}, "/"), "\\", "/", -1)
+			var key []string
+			if bucket == TemplateBucket {
+				key = []string{r.Dir, "preview", rel}
+			} else {
+				key = []string{r.Dir, rel}
+			}
+
+			uploadKey := strings.Replace(strings.Join(key, "/"), "\\", "/", -1)
 			_, err = uploader.Upload(&s3manager.UploadInput{
-				Bucket:      &WebsiteBucket,
+				Bucket:      &bucket,
 				ContentType: &contenttype,
 				Key:         aws.String(uploadKey),
 				Body:        file,
@@ -70,13 +77,8 @@ func (r *Route) Generate(ctx *Context) {
 				log.Println("Failed to upload", path, err)
 			}
 
-			fmt.Printf("successfully uploaded %s/%s\n", WebsiteBucket, uploadKey)
+			fmt.Printf("successfully uploaded %s/%s\n", bucket, uploadKey)
 		}
-	}
-	// Remove local temp files
-	err := os.RemoveAll("tmp/" + r.Category)
-	if err != nil {
-		log.Println(err)
 	}
 }
 
@@ -106,7 +108,9 @@ func (r *Route) FileDownload() {
 	directory := filepath.Join("tmp/", r.Category)
 	d := Downloader{bucket: TemplateBucket, dir: directory, Downloader: manager}
 	client := s3.New(session.New())
-	params := &s3.ListObjectsInput{Bucket: &TemplateBucket, Prefix: &r.Category}
+
+	bucketPrefix := strings.Join([]string{r.Category, "template"}, "/")
+	params := &s3.ListObjectsInput{Bucket: &TemplateBucket, Prefix: &bucketPrefix}
 	client.ListObjectsPages(params, d.eachPage)
 }
 

--- a/src/staticgen/aws/upload.go
+++ b/src/staticgen/aws/upload.go
@@ -67,6 +67,6 @@ func (r *Route) Upload(foldername, bucket string) {
 			log.Println("Failed to upload", path, err)
 		}
 
-		fmt.Printf("successfully uploaded %s/%s/%s\n", bucket, r.Dir, rel)
+		fmt.Printf("successfully uploaded %s/%s\n", bucket, uploadKey)
 	}
 }

--- a/src/staticgen/aws/upload.go
+++ b/src/staticgen/aws/upload.go
@@ -50,7 +50,13 @@ func (r *Route) Upload(foldername, bucket string) {
 			continue
 		}
 
-		uploadKey := []string{r.Dir, rel}
+		var uploadKey []string
+		if bucket == TemplateBucket {
+			uploadKey = []string{r.Dir, "template", rel}
+		} else {
+			uploadKey = []string{r.Dir, rel}
+		}
+
 		_, err = uploader.Upload(&s3manager.UploadInput{
 			Bucket:      &bucket,
 			ContentType: &contenttype,
@@ -62,11 +68,5 @@ func (r *Route) Upload(foldername, bucket string) {
 		}
 
 		fmt.Printf("successfully uploaded %s/%s/%s\n", bucket, r.Dir, rel)
-	}
-
-	// Remove local temp files
-	err := os.RemoveAll("tmp/" + foldername)
-	if err != nil {
-		log.Println(err)
 	}
 }

--- a/src/staticgen/aws/upload.go
+++ b/src/staticgen/aws/upload.go
@@ -50,17 +50,18 @@ func (r *Route) Upload(foldername, bucket string) {
 			continue
 		}
 
-		var uploadKey []string
+		var key []string
 		if bucket == TemplateBucket {
-			uploadKey = []string{r.Dir, "template", rel}
+			key = []string{r.Dir, "template", rel}
 		} else {
-			uploadKey = []string{r.Dir, rel}
+			key = []string{r.Dir, rel}
 		}
 
+		uploadKey := strings.Join(key, "/")
 		_, err = uploader.Upload(&s3manager.UploadInput{
 			Bucket:      &bucket,
 			ContentType: &contenttype,
-			Key:         aws.String(strings.Join(uploadKey, "/")),
+			Key:         aws.String(uploadKey),
 			Body:        file,
 		})
 		if err != nil {

--- a/src/staticgen/aws/utils.go
+++ b/src/staticgen/aws/utils.go
@@ -4,16 +4,22 @@ import (
 	"os"
 )
 
+var (
+	// TemplateBucket sets S3 template bucket URL
+	TemplateBucket = os.Getenv("TEMPLATE_BUCKET")
+
+	// WebsiteBucket sets S3 website bucket URL
+	WebsiteBucket = os.Getenv("WEBSITE_BUCKET")
+)
+
 type (
 	// Initialize filewalk channel
 	fileWalk chan string
 
 	// Route for s3 bucket
 	Route struct {
-		TemplateBucket string
-		WebsiteBucket  string
-		Category       string
-		Dir            string
+		Category string
+		Dir      string
 	}
 
 	// Context for templates

--- a/src/staticgen/controllers.go
+++ b/src/staticgen/controllers.go
@@ -9,10 +9,6 @@ import (
 	"staticgen/aws"
 )
 
-// Set S3 bucket URL
-var templateBucket = os.Getenv("TEMPLATE_BUCKET")
-var websiteBucket = os.Getenv("WEBSITE_BUCKET")
-
 // GenerateHandler generates website files from template files in s3
 func GenerateHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
@@ -21,7 +17,7 @@ func GenerateHandler(w http.ResponseWriter, r *http.Request) {
 	category := query.Get("category")
 	domain := query.Get("domain")
 
-	route := aws.Route{WebsiteBucket: websiteBucket, TemplateBucket: templateBucket, Category: category, Dir: domain}
+	route := aws.Route{Category: category, Dir: domain}
 	if r.Method == "POST" {
 		// Download template files from s3
 		route.FileDownload()
@@ -39,7 +35,7 @@ func GenerateHandler(w http.ResponseWriter, r *http.Request) {
 func TemplateHandler(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
 	category := query.Get("category")
-	route := aws.Route{WebsiteBucket: websiteBucket, TemplateBucket: templateBucket, Category: category, Dir: category}
+	route := aws.Route{Category: category, Dir: category}
 	if r.Method == "POST" {
 		// Recieve and unzip file
 		foldername, err := Receive(r, category)
@@ -48,13 +44,14 @@ func TemplateHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "staticgen: uploaded zipfile failed", 400)
 		}
 		// Upload to S3
-		route.Upload(foldername, route.TemplateBucket)
+		route.Upload(foldername, aws.TemplateBucket)
+
 	} else if r.Method == "GET" {
 		w.Header().Set("Content-Type", "application/zip")
 		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.zip\"", category))
-		route.BufferDownload(w, route.TemplateBucket)
+		route.BufferDownload(w, aws.TemplateBucket)
 	} else if r.Method == "DELETE" {
-		route.Delete(route.TemplateBucket)
+		route.Delete(aws.TemplateBucket)
 	} else {
 		http.Error(w, "Invalid request method", http.StatusMethodNotAllowed)
 	}
@@ -68,7 +65,7 @@ func WebsiteHandler(w http.ResponseWriter, r *http.Request) {
 	domain := query.Get("domain")
 	category := query.Get("category")
 
-	route := aws.Route{WebsiteBucket: websiteBucket, TemplateBucket: templateBucket, Category: category, Dir: domain}
+	route := aws.Route{Category: category, Dir: domain}
 	if r.Method == "POST" {
 		// Recieve and unzip file
 		foldername, err := Receive(r, category)
@@ -77,12 +74,18 @@ func WebsiteHandler(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "staticgen: uploaded zipfile failed", 400)
 		}
 		// Upload to S3
-		route.Upload(foldername, route.WebsiteBucket)
+		route.Upload(foldername, aws.WebsiteBucket)
+
+		// Remove local temp files
+		err = os.RemoveAll("tmp/" + category)
+		if err != nil {
+			log.Println(err)
+		}
 	} else if r.Method == "GET" {
 		w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s.zip\"", "Website"))
-		route.BufferDownload(w, route.WebsiteBucket)
+		route.BufferDownload(w, aws.WebsiteBucket)
 	} else if r.Method == "DELETE" {
-		route.Delete(route.WebsiteBucket)
+		route.Delete(aws.WebsiteBucket)
 	} else {
 		http.Error(w, "Invalid request method", http.StatusMethodNotAllowed)
 	}

--- a/src/staticgen/controllers.go
+++ b/src/staticgen/controllers.go
@@ -27,7 +27,13 @@ func GenerateHandler(w http.ResponseWriter, r *http.Request) {
 		context := aws.Context{}
 		decoder := json.NewDecoder(r.Body)
 		decoder.Decode(&context)
-		route.Generate(&context)
+		route.Generate(&context, aws.WebsiteBucket)
+
+		// Remove local temp files
+		err := os.RemoveAll("tmp/" + category)
+		if err != nil {
+			log.Println(err)
+		}
 	}
 }
 
@@ -45,6 +51,18 @@ func TemplateHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		// Upload to S3
 		route.Upload(foldername, aws.TemplateBucket)
+
+		// Generate preview from context data and template
+		context := aws.Context{}
+		decoder := json.NewDecoder(r.Body)
+		decoder.Decode(&context)
+		route.Generate(&context, aws.TemplateBucket)
+
+		// Remove local temp files
+		err = os.RemoveAll("tmp/" + category)
+		if err != nil {
+			log.Println(err)
+		}
 
 	} else if r.Method == "GET" {
 		w.Header().Set("Content-Type", "application/zip")

--- a/src/staticgen/controllers.go
+++ b/src/staticgen/controllers.go
@@ -27,7 +27,7 @@ func GenerateHandler(w http.ResponseWriter, r *http.Request) {
 		context := aws.Context{}
 		decoder := json.NewDecoder(r.Body)
 		decoder.Decode(&context)
-		route.Generate(&context, aws.WebsiteBucket)
+		route.Generate(&context, aws.WebsiteBucket, "template")
 
 		// Remove local temp files
 		err := os.RemoveAll("tmp/" + category)
@@ -49,6 +49,7 @@ func TemplateHandler(w http.ResponseWriter, r *http.Request) {
 			log.Println(err)
 			http.Error(w, "staticgen: uploaded zipfile failed", 400)
 		}
+
 		// Upload to S3
 		route.Upload(foldername, aws.TemplateBucket)
 
@@ -56,7 +57,7 @@ func TemplateHandler(w http.ResponseWriter, r *http.Request) {
 		context := aws.Context{}
 		decoder := json.NewDecoder(r.Body)
 		decoder.Decode(&context)
-		route.Generate(&context, aws.TemplateBucket)
+		route.Generate(&context, aws.TemplateBucket, foldername)
 
 		// Remove local temp files
 		err = os.RemoveAll("tmp/" + category)


### PR DESCRIPTION
Add a live preview static site for all uploaded templates.

## 💭 Description

Every template in the S3 bucket now include a template and preview prefix folder.
Context data for template previews are read from a `data.json` file

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [X] My code follows the code style of this project.
- [X] My changes have been adequately tested locally.
- [X] All automated tests are passing.
- [X] I have updated/added required automated tests.
- [X] Pre-commit checks are passing.

## 😪 Anything Else

<!--- Put anything else here that may be important -->
