### PR TITLE
feature: dm-112 template details

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,24 +13,22 @@ services:
     ports:
       - "5000:5000"
       - "8001:8000"
-    depends_on:
-      - db
     env_file:
       - .env
     networks:
       - backend
-  db:
-    image: mongo:latest
-    container_name: dm-mongo
-    restart: unless-stopped
-    volumes:
-      - mongodb_data:/data/db
-    ports:
-      - "27016:27017"
-    env_file:
-      - .env
-    networks:
-      - backend
+  # db:
+  #   image: mongo:latest
+  #   container_name: dm-mongo
+  #   restart: unless-stopped
+  #   volumes:
+  #     - mongodb_data:/data/db
+  #   ports:
+  #     - "27016:27017"
+  #   env_file:
+  #     - .env
+  #   networks:
+  #     - backend
   browserless:
     image: browserless/chrome:latest
     container_name: dm-browserless

--- a/src/api/views/templates.py
+++ b/src/api/views/templates.py
@@ -69,6 +69,29 @@ class TemplateView(MethodView):
     """TemplateView."""
 
     def get(self, template_id):
+        """Get template details."""
+        template = template_manager.get(document_id=template_id)
+        return jsonify(template)
+
+    def delete(self, template_id):
+        """Delete template."""
+        template = template_manager.get(document_id=template_id)
+
+        template_name = template["name"]
+        resp = requests.delete(f"{STATIC_GEN_URL}/template/?category={template_name}")
+
+        try:
+            resp.raise_for_status()
+        except requests.exceptions.HTTPError as e:
+            return jsonify({"error": str(e)})
+
+        return jsonify(template_manager.delete(document_id=template_id))
+
+
+class TemplateContentView(MethodView):
+    """TemplateContentView."""
+
+    def get(self, template_id):
         """Download template."""
         template = template_manager.get(document_id=template_id)
         resp = requests.get(f"{STATIC_GEN_URL}/template/?category={template['name']}")
@@ -89,20 +112,6 @@ class TemplateView(MethodView):
             attachment_filename=f"{template['name']}.zip",
             mimetype="application/zip",
         )
-
-    def delete(self, template_id):
-        """Delete template."""
-        template = template_manager.get(document_id=template_id)
-
-        template_name = template["name"]
-        resp = requests.delete(f"{STATIC_GEN_URL}/template/?category={template_name}")
-
-        try:
-            resp.raise_for_status()
-        except requests.exceptions.HTTPError as e:
-            return jsonify({"error": str(e)})
-
-        return jsonify(template_manager.delete(document_id=template_id))
 
 
 class TemplateAttributesView(MethodView):

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,12 @@ from api.views.categories import CategoriesView, CategoryCheckView
 from api.views.email_address import EmailAddressView
 from api.views.hosted_zones import HostedZonesView
 from api.views.proxies import ProxiesView, ProxyView
-from api.views.templates import TemplateAttributesView, TemplatesView, TemplateView
+from api.views.templates import (
+    TemplateAttributesView,
+    TemplateContentView,
+    TemplatesView,
+    TemplateView,
+)
 from api.views.websites import (
     WebsiteCategorizeView,
     WebsiteContentView,
@@ -45,6 +50,7 @@ rules = [
     ("/proxy/<proxy_id>/", ProxyView),
     ("/templates/", TemplatesView),
     ("/template/<template_id>/", TemplateView),
+    ("/template/<template_id>/content/", TemplateContentView),
     ("/templates/attributes/", TemplateAttributesView),
     ("/websites/", WebsitesView),
     ("/website/<website_id>/", WebsiteView),


### PR DESCRIPTION
Added a get template details endpoint

## 💭 Description
getting template details endpoint created:
`/api/template/<template_id>/`
downloading template content has been moved to:
`/api/template/<template_id>/content/`

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [X] My code follows the code style of this project.
- [X] My changes have been adequately tested locally.
- [X] All automated tests are passing.
- [X] I have updated/added required automated tests.
- [X] Pre-commit checks are passing.

## 😪 Anything Else

<!--- Put anything else here that may be important -->
