### PR TITLE
feature: dm-234 add ssl enabled www to cloudfront

### DIFF
--- a/src/utils/aws/site_handler.py
+++ b/src/utils/aws/site_handler.py
@@ -172,7 +172,7 @@ def setup_cloudfront(domain, certificate_arn):
     distribution_config = {
         "DistributionConfig": {
             "CallerReference": unique_identifier,
-            "Aliases": {"Quantity": 1, "Items": [domain_name]},
+            "Aliases": {"Quantity": 2, "Items": [domain_name, f"www.{domain_name}"]},
             "DefaultRootObject": "home.html",
             "Comment": "Managed by Domain Manager",
             "Enabled": True,
@@ -330,7 +330,19 @@ def delete_dns(domain, endpoint=None, ip_address=None):
                                     "DNSName": endpoint,
                                 },
                             },
-                        }
+                        },
+                        {
+                            "Action": "DELETE",
+                            "ResourceRecordSet": {
+                                "Name": f"www.{domain_name}",
+                                "Type": "CNAME",
+                                "AliasTarget": {
+                                    "HostedZoneId": "Z2FDTNDATAQYW2",
+                                    "EvaluateTargetHealth": False,
+                                    "DNSName": endpoint,
+                                },
+                            },
+                        },
                     ],
                 },
             )

--- a/src/utils/aws/site_handler.py
+++ b/src/utils/aws/site_handler.py
@@ -466,14 +466,12 @@ def get_acm_record(cert_arn):
     """Get acm route 53 record for validation."""
     certificate_description = acm.describe_certificate(CertificateArn=cert_arn)
 
-    records = [
+    return [
         description.get("ResourceRecord", None)
         for description in certificate_description.get("Certificate", {}).get(
             "DomainValidationOptions"
         )
     ]
-
-    return records
 
 
 def get_hosted_zone_ns_records(hosted_zone_id):

--- a/src/utils/aws/site_handler.py
+++ b/src/utils/aws/site_handler.py
@@ -327,7 +327,7 @@ def generate_ssl_certs(domain):
     requested_certificate = acm.request_certificate(
         DomainName=domain_name,
         ValidationMethod="DNS",
-        SubjectAlternativeNames=[domain_name],
+        SubjectAlternativeNames=[domain_name, f"www.{domain_name}"],
         DomainValidationOptions=[
             {"DomainName": domain_name, "ValidationDomain": domain_name},
         ],


### PR DESCRIPTION
Enable WWW
NOTE: Take down all live sites before merging. You can relaunch sites once this PR has been merged.

## 💭 Description

Add WWW on all sites launched from domain manager to cloudfront and to external IP addresses

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [X] My code follows the code style of this project.
- [X] My changes have been adequately tested locally.
- [X] All automated tests are passing.
- [X] I have updated/added required automated tests.
- [X] Pre-commit checks are passing.

## 😪 Anything Else

<!--- Put anything else here that may be important -->
