### PR TITLE
feature: dm-296 content approval workflow

### DIFF
--- a/src/api/manager.py
+++ b/src/api/manager.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 # Third-Party Libraries
 from bson.objectid import ObjectId
+from flask import g
 import pymongo
 
 # cisagov Libraries
@@ -92,6 +93,11 @@ class Manager:
         elif type(data) is list:
             for item in data:
                 item["updated"] = datetime.utcnow().isoformat()
+        return data
+
+    def add_user(self, data):
+        """Add user attribute to data on save."""
+        data["created_by"] = g.get("username")
         return data
 
     def clean_data(self, data):
@@ -218,6 +224,11 @@ class TemplateManager(Manager):
             unique_indexes=["name"],
         )
 
+    def save(self, data):
+        """Save with user data."""
+        data = self.add_user(data)
+        super().save(data)
+
 
 class UserManager(Manager):
     """UserManager."""
@@ -241,6 +252,11 @@ class DomainManager(Manager):
             schema=DomainSchema,
             unique_indexes=["name"],
         )
+
+    def save(self, data):
+        """Save with user data."""
+        data = self.add_user(data)
+        super().save(data)
 
 
 class LogManager(Manager):

--- a/src/api/manager.py
+++ b/src/api/manager.py
@@ -81,23 +81,22 @@ class Manager:
         """Add created attribute to data on save."""
         if type(data) is dict:
             data["created"] = datetime.utcnow().isoformat()
+            data["created_by"] = g.get("username")
         elif type(data) is list:
             for item in data:
                 item["created"] = datetime.utcnow().isoformat()
+                item["created_by"] = g.get("username")
         return data
 
     def add_updated(self, data):
         """Update updated data on update."""
         if type(data) is dict:
             data["updated"] = datetime.utcnow().isoformat()
+            data["updated_by"] = g.get("username")
         elif type(data) is list:
             for item in data:
                 item["updated"] = datetime.utcnow().isoformat()
-        return data
-
-    def add_user(self, data):
-        """Add user attribute to data on save."""
-        data["created_by"] = g.get("username")
+                item["updated_by"] = g.get("username")
         return data
 
     def clean_data(self, data):
@@ -224,11 +223,6 @@ class TemplateManager(Manager):
             unique_indexes=["name"],
         )
 
-    def save(self, data):
-        """Save with user data."""
-        data = self.add_user(data)
-        super().save(data)
-
 
 class UserManager(Manager):
     """UserManager."""
@@ -252,11 +246,6 @@ class DomainManager(Manager):
             schema=DomainSchema,
             unique_indexes=["name"],
         )
-
-    def save(self, data):
-        """Save with user data."""
-        data = self.add_user(data)
-        super().save(data)
 
 
 class LogManager(Manager):

--- a/src/api/schemas/application_schema.py
+++ b/src/api/schemas/application_schema.py
@@ -1,12 +1,12 @@
 """API Schema."""
 # Third-Party Libraries
-from marshmallow import EXCLUDE, Schema, fields
+from marshmallow import EXCLUDE, fields
 
 # cisagov Libraries
-from api.schemas.fields import DateTimeField
+from api.schemas.base_schema import BaseSchema
 
 
-class ApplicationSchema(Schema):
+class ApplicationSchema(BaseSchema):
     """Application Schema."""
 
     class Meta:
@@ -14,11 +14,8 @@ class ApplicationSchema(Schema):
 
         unknown = EXCLUDE
 
-    _id = fields.Str()
     name = fields.Str()
     requester_name = fields.Str()
     contact_name = fields.Str()
     contact_email = fields.Email()
     contact_phone = fields.Str()
-    created = DateTimeField()
-    updated = DateTimeField()

--- a/src/api/schemas/base_schema.py
+++ b/src/api/schemas/base_schema.py
@@ -1,0 +1,20 @@
+"""BaseSchema."""
+# Third-Party Libraries
+from marshmallow import Schema, fields
+
+# cisagov Libraries
+from api.schemas.fields import DateTimeField
+
+
+class BaseSchema(Schema):
+    """
+    BaseSchema.
+
+    The base schema for all collections.
+    """
+
+    _id = fields.Str()
+    created = DateTimeField(allow_none=True)
+    created_by = fields.Str()
+    updated = DateTimeField(allow_none=True)
+    updated_by = fields.Str()

--- a/src/api/schemas/domain_schema.py
+++ b/src/api/schemas/domain_schema.py
@@ -4,6 +4,7 @@ from marshmallow import EXCLUDE, Schema, fields, pre_load, validate, validates_s
 
 # cisagov Libraries
 from api.schemas import application_schema
+from api.schemas.base_schema import BaseSchema
 from api.schemas.fields import DateTimeField
 from utils import validator
 
@@ -135,7 +136,7 @@ class Record(Schema):
         return data
 
 
-class DomainSchema(Schema):
+class DomainSchema(BaseSchema):
     """DomainSchema."""
 
     class Meta:
@@ -143,7 +144,6 @@ class DomainSchema(Schema):
 
         unknown = EXCLUDE
 
-    _id = fields.Str()
     name = fields.Str(validate=validator.is_valid_domain)
     description = fields.Str()
     category = fields.Str(validate=validator.is_valid_category)
@@ -159,7 +159,6 @@ class DomainSchema(Schema):
     is_email_active = fields.Boolean()
     launch_date = DateTimeField()
     profile = fields.Dict()
-    created_by = fields.Str()
     history = fields.List(fields.Nested(History))
     cloudfront = fields.Dict()
     acm = fields.Dict()

--- a/src/api/schemas/domain_schema.py
+++ b/src/api/schemas/domain_schema.py
@@ -159,6 +159,7 @@ class DomainSchema(Schema):
     is_email_active = fields.Boolean()
     launch_date = DateTimeField()
     profile = fields.Dict()
+    created_by = fields.Str()
     history = fields.List(fields.Nested(History))
     cloudfront = fields.Dict()
     acm = fields.Dict()

--- a/src/api/schemas/domain_schema.py
+++ b/src/api/schemas/domain_schema.py
@@ -151,6 +151,7 @@ class DomainSchema(Schema):
     ip_address = fields.Str()
     application_id = fields.Str(allow_none=True)
     is_active = fields.Boolean()
+    is_approved = fields.Boolean(default=False)
     is_available = fields.Boolean(default=True)
     is_launching = fields.Boolean(default=False)
     is_delaunching = fields.Boolean(default=False)

--- a/src/api/schemas/log_schema.py
+++ b/src/api/schemas/log_schema.py
@@ -1,12 +1,12 @@
 """Log Schema."""
 # Third-Party Libraries
-from marshmallow import EXCLUDE, Schema, fields
+from marshmallow import EXCLUDE, fields
 
 # cisagov Libraries
-from api.schemas.fields import DateTimeField
+from api.schemas.base_schema import BaseSchema
 
 
-class LogSchema(Schema):
+class LogSchema(BaseSchema):
     """LogSchema."""
 
     class Meta:
@@ -14,7 +14,6 @@ class LogSchema(Schema):
 
         unkown = EXCLUDE
 
-    _id = fields.Str()
     username = fields.Str()
     is_admin = fields.Bool()
     status_code = fields.Number()
@@ -22,5 +21,4 @@ class LogSchema(Schema):
     method = fields.Str()
     args = fields.Dict()
     json = fields.Field(allow_none=True)
-    created = DateTimeField()
     error = fields.Str()

--- a/src/api/schemas/template_schema.py
+++ b/src/api/schemas/template_schema.py
@@ -18,5 +18,6 @@ class TemplateSchema(Schema):
     _id = fields.Str()
     name = fields.Str(validate=is_valid_category)
     s3_url = fields.Str()
+    is_approved = fields.Boolean(default=False)
     created = DateTimeField()
     updated = DateTimeField()

--- a/src/api/schemas/template_schema.py
+++ b/src/api/schemas/template_schema.py
@@ -21,3 +21,4 @@ class TemplateSchema(Schema):
     is_approved = fields.Boolean(default=False)
     created = DateTimeField()
     updated = DateTimeField()
+    created_by = fields.Str()

--- a/src/api/schemas/template_schema.py
+++ b/src/api/schemas/template_schema.py
@@ -1,13 +1,13 @@
 """API Schema."""
 # Third-Party Libraries
-from marshmallow import EXCLUDE, Schema, fields
+from marshmallow import EXCLUDE, fields
 
 # cisagov Libraries
-from api.schemas.fields import DateTimeField
+from api.schemas.base_schema import BaseSchema
 from utils.validator import is_valid_category
 
 
-class TemplateSchema(Schema):
+class TemplateSchema(BaseSchema):
     """Template Schema."""
 
     class Meta:
@@ -15,10 +15,6 @@ class TemplateSchema(Schema):
 
         unknown = EXCLUDE
 
-    _id = fields.Str()
     name = fields.Str(validate=is_valid_category)
     s3_url = fields.Str()
     is_approved = fields.Boolean(default=False)
-    created = DateTimeField()
-    updated = DateTimeField()
-    created_by = fields.Str()

--- a/src/api/schemas/user_shema.py
+++ b/src/api/schemas/user_shema.py
@@ -1,13 +1,14 @@
 """API Schema."""
 # Third-Party Libraries
-from marshmallow import EXCLUDE, Schema, fields
+from marshmallow import EXCLUDE, fields
 
 # cisagov Libraries
+from api.schemas.base_schema import BaseSchema
 from api.schemas.fields import DateTimeField
 from utils.validator import is_valid_category
 
 
-class UserSchema(Schema):
+class UserSchema(BaseSchema):
     """User Schema."""
 
     class Meta:
@@ -15,7 +16,6 @@ class UserSchema(Schema):
 
         unknown = EXCLUDE
 
-    _id = fields.Str()
     Attributes = fields.List(fields.Dict())
     Enabled = fields.Boolean()
     UserCreateDate = DateTimeField()

--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -271,7 +271,7 @@ class DomainGenerateView(MethodView):
 
         template = template_manager.get(filter_data={"name": category})
 
-        if template.get("is_approved", False) is False:
+        if not template.get("is_approved", False):
             return jsonify({"error": "Template is not authorized for use."}), 401
 
         domain = domain_manager.get(document_id=domain_id)
@@ -343,7 +343,7 @@ class DomainLaunchView(MethodView):
         if not domain["is_available"]:
             return "Domain is not available for launching at the moment.", 400
 
-        if domain.get("is_approved", False) is False:
+        if not domain.get("is_approved", False):
             return (
                 "Website content is not approved. Please reach out to an admin for approval.",
                 400,

--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -501,24 +501,25 @@ class DomainApprovalView(MethodView):
 
     def get(self, domain_id):
         """Approve uploaded content pending for review."""
-        template = domain_manager.get(document_id=domain_id)
+        domain = domain_manager.get(document_id=domain_id)
+        return domain.get("is_approved")
 
-        if template.get("is_approved", False):
+    def post(self, domain_id):
+        """Approve uploaded content pending for review."""
+        domain = domain_manager.get(document_id=domain_id)
+
+        if domain.get("is_approved", False):
             return jsonify({"error": "This content is already approved"}), 400
 
         return jsonify(
             domain_manager.update(document_id=domain_id, data={"is_approved": True})
         )
 
-
-class DomainDisapprovalView(MethodView):
-    """Domain disapproval view."""
-
-    def get(self, domain_id):
+    def delete(self, domain_id):
         """Disapprove previously approved content."""
-        template = domain_manager.get(document_id=domain_id)
+        domain = domain_manager.get(document_id=domain_id)
 
-        if not template.get("is_approved", True):
+        if not domain.get("is_approved", True):
             return jsonify({"error": "This content is not yet approved"}), 400
 
         return jsonify(

--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -502,11 +502,6 @@ class DomainApprovalView(MethodView):
     def get(self, domain_id):
         """Approve uploaded content pending for review."""
         domain = domain_manager.get(document_id=domain_id)
-        return domain.get("is_approved")
-
-    def post(self, domain_id):
-        """Approve uploaded content pending for review."""
-        domain = domain_manager.get(document_id=domain_id)
 
         if domain.get("is_approved", False):
             return jsonify({"error": "This content is already approved"}), 400

--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -297,13 +297,10 @@ class DomainGenerateView(MethodView):
             post_data = {
                 "s3_url": f"https://{WEBSITE_BUCKET}.s3.amazonaws.com/{domain_name}/",
                 "category": category,
+                "is_approved": True,
                 "is_available": True,
                 "is_generating_template": False,
             }
-
-            # Content automatically approved if uploaded by admins
-            if g.is_admin:
-                post_data["is_approved"] = True
 
             domain_manager.update(
                 document_id=domain_id,

--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -494,3 +494,18 @@ class DomainDeployedCheckView(MethodView):
                 ),
                 400,
             )
+
+
+class DomainApprovalView(MethodView):
+    """Domain approval view."""
+
+    def get(self, domain_id):
+        """Approve uploaded content pending for review."""
+        template = domain_manager.get(document_id=domain_id)
+
+        if template.get("is_approved", False):
+            return jsonify({"error": "This content is already approved"}), 400
+
+        return jsonify(
+            domain_manager.update(document_id=domain_id, data={"is_approved": True})
+        )

--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -509,3 +509,18 @@ class DomainApprovalView(MethodView):
         return jsonify(
             domain_manager.update(document_id=domain_id, data={"is_approved": True})
         )
+
+
+class DomainDisapprovalView(MethodView):
+    """Domain disapproval view."""
+
+    def get(self, domain_id):
+        """Disapprove previously approved content."""
+        template = domain_manager.get(document_id=domain_id)
+
+        if not template.get("is_approved", True):
+            return jsonify({"error": "This content is not yet approved"}), 400
+
+        return jsonify(
+            domain_manager.update(document_id=domain_id, data={"is_approved": False})
+        )

--- a/src/api/views/template_views.py
+++ b/src/api/views/template_views.py
@@ -153,3 +153,20 @@ class TemplateApprovalView(MethodView):
         return jsonify(
             template_manager.update(document_id=template_id, data={"is_approved": True})
         )
+
+
+class TemplateDisapprovalView(MethodView):
+    """Template disapproval view."""
+
+    def get(self, template_id):
+        """Disapprove a previously approved template."""
+        template = template_manager.get(document_id=template_id)
+
+        if not template.get("is_approved", True):
+            return jsonify({"error": "This template is not yet approved"}), 400
+
+        return jsonify(
+            template_manager.update(
+                document_id=template_id, data={"is_approved": False}
+            )
+        )

--- a/src/api/views/template_views.py
+++ b/src/api/views/template_views.py
@@ -138,3 +138,18 @@ class TemplateAttributesView(MethodView):
                 "state",
             ]
         )
+
+
+class TemplateApprovalView(MethodView):
+    """Template approval view."""
+
+    def get(self, template_id):
+        """Approve a template pending for review."""
+        template = template_manager.get(document_id=template_id)
+
+        if template.get("is_approved", False):
+            return jsonify({"error": "This template is already approved"}), 400
+
+        return jsonify(
+            template_manager.update(document_id=template_id, data={"is_approved": True})
+        )

--- a/src/api/views/template_views.py
+++ b/src/api/views/template_views.py
@@ -144,11 +144,6 @@ class TemplateApprovalView(MethodView):
     """Template approval view."""
 
     def get(self, template_id):
-        """Get template approval status."""
-        template = template_manager.get(document_id=template_id)
-        return template.get("is_approved", False)
-
-    def post(self, template_id):
         """Approve a template pending for review."""
         template = template_manager.get(document_id=template_id)
 

--- a/src/api/views/template_views.py
+++ b/src/api/views/template_views.py
@@ -144,6 +144,11 @@ class TemplateApprovalView(MethodView):
     """Template approval view."""
 
     def get(self, template_id):
+        """Get template approval status."""
+        template = template_manager.get(document_id=template_id)
+        return template.get("is_approved", False)
+
+    def post(self, template_id):
         """Approve a template pending for review."""
         template = template_manager.get(document_id=template_id)
 
@@ -154,11 +159,7 @@ class TemplateApprovalView(MethodView):
             template_manager.update(document_id=template_id, data={"is_approved": True})
         )
 
-
-class TemplateDisapprovalView(MethodView):
-    """Template disapproval view."""
-
-    def get(self, template_id):
+    def delete(self, template_id):
         """Disapprove a previously approved template."""
         template = template_manager.get(document_id=template_id)
 

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,6 @@ from api.views.domain_views import (
     DomainCategorizeView,
     DomainContentView,
     DomainDeployedCheckView,
-    DomainDisapprovalView,
     DomainGenerateView,
     DomainLaunchView,
     DomainRecordView,
@@ -83,7 +82,6 @@ login_rules = [
 admin_rules = [
     ("/application/<application_id>/", ApplicationView),
     ("/domain/<domain_id>/approve/", DomainApprovalView),
-    ("/domain/<domain_id>/disapprove/", DomainDisapprovalView),
     ("/template/<template_id>/approve/", TemplateApprovalView),
     ("/users/", UsersView),
     ("/user/<username>/confirm", UserConfirmView),

--- a/src/main.py
+++ b/src/main.py
@@ -31,7 +31,6 @@ from api.views.template_views import (
     TemplateApprovalView,
     TemplateAttributesView,
     TemplateContentView,
-    TemplateDisapprovalView,
     TemplatesView,
     TemplateView,
 )
@@ -86,7 +85,6 @@ admin_rules = [
     ("/domain/<domain_id>/approve/", DomainApprovalView),
     ("/domain/<domain_id>/disapprove/", DomainDisapprovalView),
     ("/template/<template_id>/approve/", TemplateApprovalView),
-    ("/template/<template_id>/disapprove/", TemplateDisapprovalView),
     ("/users/", UsersView),
     ("/user/<username>/confirm", UserConfirmView),
     ("/user/<username>/admin", UserAdminStatusView),

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from api.views.domain_views import (
     DomainCategorizeView,
     DomainContentView,
     DomainDeployedCheckView,
+    DomainDisapprovalView,
     DomainGenerateView,
     DomainLaunchView,
     DomainRecordView,
@@ -30,6 +31,7 @@ from api.views.template_views import (
     TemplateApprovalView,
     TemplateAttributesView,
     TemplateContentView,
+    TemplateDisapprovalView,
     TemplatesView,
     TemplateView,
 )
@@ -82,7 +84,9 @@ login_rules = [
 admin_rules = [
     ("/application/<application_id>/", ApplicationView),
     ("/domain/<domain_id>/approve/", DomainApprovalView),
+    ("/domain/<domain_id>/disapprove/", DomainDisapprovalView),
     ("/template/<template_id>/approve/", TemplateApprovalView),
+    ("/template/<template_id>/disapprove/", TemplateDisapprovalView),
     ("/users/", UsersView),
     ("/user/<username>/confirm", UserConfirmView),
     ("/user/<username>/admin", UserAdminStatusView),

--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,7 @@ from api.views.domain_views import (
 from api.views.email_address_views import EmailAddressView
 from api.views.proxy_views import ProxiesView, ProxyView
 from api.views.template_views import (
+    TemplateApprovalView,
     TemplateAttributesView,
     TemplateContentView,
     TemplatesView,
@@ -79,6 +80,7 @@ login_rules = [
 
 admin_rules = [
     ("/application/<application_id>/", ApplicationView),
+    ("/template/<template_id>/approve/", TemplateApprovalView),
     ("/users/", UsersView),
     ("/user/<username>/confirm", UserConfirmView),
     ("/user/<username>/admin", UserAdminStatusView),

--- a/src/main.py
+++ b/src/main.py
@@ -14,6 +14,7 @@ from api.views.application_views import ApplicationsView, ApplicationView
 from api.views.auth_views import RefreshTokenView, RegisterView, SignInView
 from api.views.category_views import CategoriesView, ExternalCategoriesView
 from api.views.domain_views import (
+    DomainApprovalView,
     DomainCategorizeView,
     DomainContentView,
     DomainDeployedCheckView,
@@ -80,6 +81,7 @@ login_rules = [
 
 admin_rules = [
     ("/application/<application_id>/", ApplicationView),
+    ("/domain/<domain_id>/approve/", DomainApprovalView),
     ("/template/<template_id>/approve/", TemplateApprovalView),
     ("/users/", UsersView),
     ("/user/<username>/confirm", UserConfirmView),


### PR DESCRIPTION
Implement an authorization workflow for content generated by general users

## 💭 Description
Re-enable the ability for general users to add templates and upload content directly to a website
Create endpoints for admins to approve content generated by general users
add `created by` fields for templates and domains
prevent unapproved content from being launched live

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [X] My code follows the code style of this project.
- [X] My changes have been adequately tested locally.
- [X] All automated tests are passing.
- [X] I have updated/added required automated tests.
- [X] Pre-commit checks are passing.

## 😪 Anything Else

<!--- Put anything else here that may be important -->
