### PR TITLE
feature: dm-308 upload bulk domains

### DIFF
--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -49,15 +49,15 @@ class DomainsView(MethodView):
 
     def post(self):
         """Create a new domain."""
-        # if not g.is_admin:
-        #     return (
-        #         jsonify(
-        #             {
-        #                 "error": "User does not have admin rights, can not create a new domain"
-        #             }
-        #         ),
-        #         400,
-        #     )
+        if not g.is_admin:
+            return (
+                jsonify(
+                    {
+                        "error": "User does not have admin rights, can not create a new domain"
+                    }
+                ),
+                400,
+            )
         response = []
         for domain_name in request.json:
             data = validate_data({"name": domain_name}, DomainSchema)

--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -49,20 +49,23 @@ class DomainsView(MethodView):
 
     def post(self):
         """Create a new domain."""
-        if not g.is_admin:
-            return (
-                jsonify(
-                    {
-                        "error": "User does not have admin rights, can not create a new domain"
-                    }
-                ),
-                400,
-            )
+        # if not g.is_admin:
+        #     return (
+        #         jsonify(
+        #             {
+        #                 "error": "User does not have admin rights, can not create a new domain"
+        #             }
+        #         ),
+        #         400,
+        #     )
         response = []
         for domain_name in request.json:
             data = validate_data({"name": domain_name}, DomainSchema)
             if domain_manager.get(filter_data={"name": data["name"]}):
-                return jsonify({"error": "Domain already exists."}), 400
+                logger.error(f"{domain_name} already exists.")
+                response.append({domain_name: "Skipped. Already exists."})
+                continue
+
             caller_ref = str(uuid4())
             resp = route53.create_hosted_zone(
                 Name=data["name"], CallerReference=caller_ref


### PR DESCRIPTION
Create the ability to create multiple domains in bulk

## 💭 Description
The new expected post body is a JSON list
```json
["domain1.com", "domain2.com", "domain3.com"]
```
the updated response will now be a list of nameservers returned:
```json
[
    {
        "domain1.com": [
            "ns-207.awsdns-25.com",
            "ns-1569.awsdns-04.co.uk",
            "ns-1140.awsdns-14.org",
            "ns-777.awsdns-33.net"
        ]
    },
    {
        "domain2.com": [
            "ns-1914.awsdns-47.co.uk",
            "ns-968.awsdns-57.net",
            "ns-308.awsdns-38.com",
            "ns-1191.awsdns-20.org"
        ]
    },
    {
        "domain3.com": [
            "ns-231.awsdns-28.com",
            "ns-888.awsdns-47.net",
            "ns-1888.awsdns-44.co.uk",
            "ns-1322.awsdns-37.org"
        ]
    }
]
```

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [X] My code follows the code style of this project.
- [X] My changes have been adequately tested locally.
- [X] All automated tests are passing.
- [X] I have updated/added required automated tests.
- [X] Pre-commit checks are passing.

## 😪 Anything Else

<!--- Put anything else here that may be important -->
