### PR TITLE
upload html files properly when not from template

### DIFF
--- a/src/staticgen/aws/parse.go
+++ b/src/staticgen/aws/parse.go
@@ -46,6 +46,14 @@ func (r *Route) Generate(ctx *Context, bucket, isTemplate, foldername string) {
 			if ext == ".html" && isTemplate == "true" {
 				contenttype = "text/html"
 				file = parse(path, rel, ctx)
+			} else if ext == ".html" {
+				log.Println("opening as html file")
+				contenttype = "text/html"
+				file, err = os.Open(path)
+				if err != nil {
+					log.Println("Failed opening html file", path, err)
+					continue
+				}
 			} else if ext == ".css" {
 				contenttype = "text/css"
 				file, err = os.Open(path)


### PR DESCRIPTION
# <!--- Provide JIRA issue and general summary in title above. -->

## 💭 Description

<!--- Describe changes in detail -->

HTML files were not getting the content type set properly if from a non-go-template. Set proper content type when dealing with these files.

## ✅ Checklist

<!--- Put an `x` in what you have completed -->

- [ ] My code follows the code style of this project.
- [ ] My changes have been adequately tested locally.
- [ ] All automated tests are passing.
- [ ] I have updated/added required automated tests.
- [ ] Pre-commit checks are passing.

## 😪 Anything Else

<!--- Put anything else here that may be important -->
