### PR TITLE
feature: dm-376 mark apex records as live sites

### DIFF
--- a/src/utils/apex_records.py
+++ b/src/utils/apex_records.py
@@ -1,5 +1,6 @@
 """Apex records."""
-from typing import Dict, Any
+# Standard Python Libraries
+from typing import Any, Union
 
 
 def contains_apex_record(domain: dict):
@@ -14,6 +15,6 @@ def contains_apex_record(domain: dict):
     )
 
 
-def is_apex_record(record: Dict[Any, Any], domain_name: str):
+def is_apex_record(record: Union[Any, Any], domain_name: str):
     """Check if it is an apex record."""
     return record["name"] == domain_name and record["record_type"] == "A"

--- a/src/utils/apex_records.py
+++ b/src/utils/apex_records.py
@@ -1,4 +1,5 @@
 """Apex records."""
+from typing import Dict, Any
 
 
 def contains_apex_record(domain: dict):
@@ -13,6 +14,6 @@ def contains_apex_record(domain: dict):
     )
 
 
-def is_apex_record(record: dict, domain_name: str):
+def is_apex_record(record: Dict[Any, Any], domain_name: str):
     """Check if it is an apex record."""
     return record["name"] == domain_name and record["record_type"] == "A"

--- a/src/utils/apex_records.py
+++ b/src/utils/apex_records.py
@@ -1,20 +1,14 @@
 """Apex records."""
 # Standard Python Libraries
-from typing import Any, Union
+from functools import partial
 
 
 def contains_apex_record(domain: dict):
     """Check if contains an apex record."""
-    return bool(
-        next(
-            filter(
-                lambda x: is_apex_record(x, domain["name"]), domain.get("records", [])
-            ),
-            False,
-        )
-    )
+    f = partial(is_apex_record, domain["name"])
+    return bool(next(filter(f, domain.get("records", [])), False))
 
 
-def is_apex_record(record: Union[Any, Any], domain_name: str):
+def is_apex_record(domain_name: str, record: dict):
     """Check if it is an apex record."""
     return record["name"] == domain_name and record["record_type"] == "A"

--- a/src/utils/apex_records.py
+++ b/src/utils/apex_records.py
@@ -1,0 +1,18 @@
+"""Apex records."""
+
+
+def contains_apex_record(domain: dict):
+    """Check if contains an apex record."""
+    return bool(
+        next(
+            filter(
+                lambda x: is_apex_record(x, domain["name"]), domain.get("records", [])
+            ),
+            False,
+        )
+    )
+
+
+def is_apex_record(record: dict, domain_name: str):
+    """Check if it is an apex record."""
+    return record["name"] == domain_name and record["record_type"] == "A"

--- a/src/utils/apex_records.py
+++ b/src/utils/apex_records.py
@@ -1,6 +1,6 @@
 """Apex records."""
 # Standard Python Libraries
-from typing import Any, Union
+from typing import Any
 
 
 def contains_apex_record(domain: dict):
@@ -15,6 +15,6 @@ def contains_apex_record(domain: dict):
     )
 
 
-def is_apex_record(record: Union[Any, Any], domain_name: str):
+def is_apex_record(record: Any, domain_name: str):
     """Check if it is an apex record."""
     return record["name"] == domain_name and record["record_type"] == "A"


### PR DESCRIPTION
Mark websites deployed externally as active sites when an apex record is created.

## 🗣 Description ##
When an apex record is created, the domain will be marked as an active site and not available for launch within the Domain Manager. When deleted, it'll be inactive and available for launch again.

## 💭 Motivation and context ##
Clarify what domains are currently live even if they're deployed outside of Domain Manager to minimize any confusion

## 🧪 Testing ##
Tested locally and reviewed.

## 📷 Screenshots (if appropriate) ##

<!-- Remove this section and header if not needed -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [X] This PR has an informative and human-readable title.
* [X] Changes are limited to a single goal - _eschew scope creep!_
* [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [X] All relevant type-of-change labels have been added.
* [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [X] All new and existing tests pass.
