### PR TITLE
feature: cpd-44 delay site launch email notification until site deployed

### DIFF
--- a/src/utils/aws/site_handler.py
+++ b/src/utils/aws/site_handler.py
@@ -111,6 +111,10 @@ def launch_site(domain):
     # setup DNS
     setup_dns(domain=domain, endpoint=distribution_endpoint)
 
+    # wait for cloudfront to be deployed
+    waiter = cloudfront.get_waiter("distribution_deployed")
+    waiter.wait(Id=distribution_id)
+
     return {
         "cloudfront": {
             "id": distribution_id,


### PR DESCRIPTION
add waiter to ensure distribution is deployed prior to sending a notification email

## 🗣 Description ##
Ensure the cloudfront distribution deployment status, which can take awhile, to be set to deployed before sending out a notification email that lets the user know its deployed.

## 💭 Motivation and context ##
Email notification is sent prematurely before the website deployment process is complete. Needed to delay notification until the website is live.

## 🧪 Testing ##
Successfully tested locally with email sent after the cloudfront distribution status has been set to deployed

## 📷 Screenshots (if appropriate) ##
<img width="589" alt="Screen Shot 2021-05-18 at 9 18 51 PM" src="https://user-images.githubusercontent.com/24395434/118746930-b3ccb880-b81e-11eb-8012-9a352d72b00a.png">

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [X] This PR has an informative and human-readable title.
* [X] Changes are limited to a single goal - _eschew scope creep!_
* [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [X] All relevant type-of-change labels have been added.
* [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [X] Tests have been added and/or modified to cover the changes in this PR.
* [X] All new and existing tests pass.
