### PR TITLE
fix send wrong data to create distribution

### DIFF
--- a/src/utils/aws/site_handler.py
+++ b/src/utils/aws/site_handler.py
@@ -179,44 +179,42 @@ def setup_cloudfront(domain, certificate_arn):
     domain_name = domain["name"]
 
     distribution_config = {
-        "DistributionConfig": {
-            "CallerReference": unique_identifier,
-            "Aliases": {"Quantity": 2, "Items": [domain_name, f"www.{domain_name}"]},
-            "DefaultRootObject": "home.html",
-            "Comment": "Managed by Domain Manager",
-            "Enabled": True,
-            "Origins": {
-                "Quantity": 1,
-                "Items": [
-                    {
-                        "Id": "1",
-                        "DomainName": WEBSITE_BUCKET_URL,
-                        "OriginPath": f"/{domain_name}",
-                        "CustomOriginConfig": {
-                            "HTTPPort": 80,
-                            "HTTPSPort": 443,
-                            "OriginProtocolPolicy": "http-only",
-                        },
-                    }
-                ],
+        "CallerReference": unique_identifier,
+        "Aliases": {"Quantity": 2, "Items": [domain_name, f"www.{domain_name}"]},
+        "DefaultRootObject": "home.html",
+        "Comment": "Managed by Domain Manager",
+        "Enabled": True,
+        "Origins": {
+            "Quantity": 1,
+            "Items": [
+                {
+                    "Id": "1",
+                    "DomainName": WEBSITE_BUCKET_URL,
+                    "OriginPath": f"/{domain_name}",
+                    "CustomOriginConfig": {
+                        "HTTPPort": 80,
+                        "HTTPSPort": 443,
+                        "OriginProtocolPolicy": "http-only",
+                    },
+                }
+            ],
+        },
+        "DefaultCacheBehavior": {
+            "TargetOriginId": "1",
+            "ViewerProtocolPolicy": "redirect-to-https",
+            "TrustedSigners": {"Quantity": 0, "Enabled": False},
+            "ForwardedValues": {
+                "QueryString": False,
+                "Cookies": {"Forward": "all"},
+                "Headers": {"Quantity": 0},
+                "QueryStringCacheKeys": {"Quantity": 0},
             },
-            "DefaultCacheBehavior": {
-                "TargetOriginId": "1",
-                "ViewerProtocolPolicy": "redirect-to-https",
-                "TrustedSigners": {"Quantity": 0, "Enabled": False},
-                "ForwardedValues": {
-                    "QueryString": False,
-                    "Cookies": {"Forward": "all"},
-                    "Headers": {"Quantity": 0},
-                    "QueryStringCacheKeys": {"Quantity": 0},
-                },
-                "MinTTL": 1000,
-            },
-            "ViewerCertificate": {
-                "ACMCertificateArn": certificate_arn,
-                "SSLSupportMethod": "sni-only",
-                "MinimumProtocolVersion": "TLSv1.2_2019",
-            },
+            "MinTTL": 1000,
+        },
+        "ViewerCertificate": {
+            "ACMCertificateArn": certificate_arn,
+            "SSLSupportMethod": "sni-only",
+            "MinimumProtocolVersion": "TLSv1.2_2019",
         },
     }
 


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Fixes launching a website by creating a CloudFront distribution properly.

Related to https://github.com/cisagov/domain-manager-ui/issues/136

<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
There was a change made sometime last week that was using a different API call. On change that broke launching a CloudFront distribution.

<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Tested locally by launching a site. It was not working before, but it is working now.

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
