### PR TITLE
Verify DNS records on launch

### DIFF
--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -21,7 +21,12 @@ from settings import STATIC_GEN_URL, WEBSITE_BUCKET, logger
 from utils.apex_records import contains_apex_record, is_apex_record
 from utils.aws import record_handler
 from utils.aws.clients import Cloudfront, Route53
-from utils.aws.site_handler import launch_domain, unlaunch_domain, verify_hosted_zone
+from utils.aws.site_handler import (
+    launch_domain,
+    unlaunch_domain,
+    verify_hosted_zone,
+    verify_launch_records,
+)
 from utils.categorization.categorize import categorize
 from utils.categorization.check import check_category
 from utils.decorators.auth import can_access_domain
@@ -378,6 +383,7 @@ class DomainLaunchView(MethodView):
 
         try:
             verify_hosted_zone(domain)
+            verify_launch_records(domain)
         except Exception as e:
             return str(e), 400
 

--- a/src/utils/aws/site_handler.py
+++ b/src/utils/aws/site_handler.py
@@ -485,3 +485,21 @@ def verify_hosted_zone(domain):
         ns_servers.append(answer.to_text())
     if len(set(ns_servers) - set(new_nameservers)) > 0:
         raise Exception("Route53 nameservers don't match NS lookup.")
+
+
+def verify_launch_records(domain):
+    """Verify that no DNS records will clash on launch."""
+    bad_records = list(
+        filter(
+            lambda x: x["name"] in [f"www.{domain['name']}", domain["name"]]
+            and x["record_type"] == "A",
+            domain.get("records", []),
+        )
+    )
+    if bad_records:
+        bad_message = ""
+        for r in bad_records:
+            bad_message += ""
+        raise Exception(
+            "You cannot have an A apex record or an A www record before launching the domain."
+        )

--- a/src/utils/aws/site_handler.py
+++ b/src/utils/aws/site_handler.py
@@ -497,9 +497,6 @@ def verify_launch_records(domain):
         )
     )
     if bad_records:
-        bad_message = ""
-        for r in bad_records:
-            bad_message += ""
         raise Exception(
             "You cannot have an A apex record or an A www record before launching the domain."
         )

--- a/tests/utils/aws/test_site_handler.py
+++ b/tests/utils/aws/test_site_handler.py
@@ -1,0 +1,24 @@
+"""Site handler function tests."""
+# Third-Party Libraries
+import pytest
+
+# cisagov Libraries
+from utils.aws import site_handler
+
+
+def test_verify_launch_records():
+    """Test verify launch records."""
+    domain = {"name": "test.xyz"}
+    with pytest.raises(Exception):
+        domain["records"] = [{"name": "test.xyz", "record_type": "A"}]
+        site_handler.verify_launch_records(domain)
+
+    with pytest.raises(Exception):
+        domain["records"] = [{"name": "www.test.xyz", "record_type": "A"}]
+        site_handler.verify_launch_records(domain)
+
+    domain["records"] = []
+    site_handler.verify_launch_records(domain)
+
+    domain["records"] = [{"name": "test.test.xyz", "record_type": "A"}]
+    site_handler.verify_launch_records(domain)


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
There was a bug when launching a site if there is a WWW A record already created for the domain. This verifies that no records exist that will cause errors when creating the cloudfront distribution.

<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
Bug launching distribution when WWW A record exists.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Tested locally by making sure we can't launch a domain when an A WWW record exists. Also wrote a unit test to test logic and functionality.

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [x] Tests have been added and/or modified to cover the changes in this PR.
* [x] All new and existing tests pass.
