### PR TITLE
feature: cpd-146 disable delete domain for general users

### DIFF
--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -160,6 +160,9 @@ class DomainView(MethodView):
 
     def delete(self, domain_id):
         """Delete domain and hosted zone."""
+        if not g.is_admin:
+            return jsonify({"error": "User not authorized to delete domains."}), 401
+
         domain = domain_manager.get(document_id=domain_id)
 
         if domain.get("is_active") and domain.get("records"):

--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -1,6 +1,7 @@
 """Domain Views."""
 # Standard Python Libraries
 from datetime import datetime
+from http import HTTPStatus
 import io
 from multiprocessing import Process
 import shutil
@@ -9,7 +10,7 @@ from uuid import uuid4
 # Third-Party Libraries
 import botocore
 from botocore.exceptions import ClientError
-from flask import g, jsonify, request, send_file
+from flask import abort, g, jsonify, request, send_file
 from flask.views import MethodView
 from marshmallow.exceptions import ValidationError
 import requests
@@ -161,7 +162,7 @@ class DomainView(MethodView):
     def delete(self, domain_id):
         """Delete domain and hosted zone."""
         if not g.is_admin:
-            return jsonify({"error": "User not authorized to delete domains."}), 401
+            abort(HTTPStatus.FORBIDDEN.value)
 
         domain = domain_manager.get(document_id=domain_id)
 


### PR DESCRIPTION
Disable the ability to delete a domain for general users

## 🗣 Description ##
Only allow admins to have the ability to delete domains. 

## 💭 Motivation and context ##
General users can unintentionally delete a domain
## 🧪 Testing ##
Tested deleting a domain as a general user and as an admin user.


## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [X] This PR has an informative and human-readable title.
* [X] Changes are limited to a single goal - _eschew scope creep!_
* [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
* [X] All relevant type-of-change labels have been added.
* [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
* [X] Tests have been added and/or modified to cover the changes in this PR.
* [X] All new and existing tests pass.
