### PR TITLE
CPD-378 User Already Exists Error

### DIFF
--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -37,6 +37,7 @@ class Settings:
 
     def to_dict(self):
         """Represent class as dict for responses."""
+        self.load()
         return {
             "SES_FORWARD_EMAIL": self.SES_FORWARD_EMAIL,
             "USER_NOTIFICATION_EMAIL": self.USER_NOTIFICATION_EMAIL,

--- a/src/api/views/settings_views.py
+++ b/src/api/views/settings_views.py
@@ -17,7 +17,6 @@ class SettingsView(MethodView):
 
     def get(self):
         """Get settings from database."""
-        settings.load()
         return jsonify(settings.to_dict())
 
     def put(self):

--- a/src/utils/notifications.py
+++ b/src/utils/notifications.py
@@ -36,7 +36,7 @@ class Notification:
         return {
             "email_received": {
                 "send_to": "ForwardEmail",
-                "subject": f"[Domain Manager] FW: {context['subject']}",
+                "subject": f"[Domain Manager] FW: {context.get('subject', '')}",
                 "text_content": render_template_string(
                     "emails/email_received.html", **context
                 ),
@@ -104,7 +104,6 @@ class Notification:
             email = self.context["UserEmail"]
             addresses.append(email)
         elif content["send_to"] == "ForwardEmail":
-            settings.load()
             addresses.append(settings.to_dict()["SES_FORWARD_EMAIL"])
 
         return addresses
@@ -119,10 +118,11 @@ class Notification:
         addresses = self.get_to_addresses(content)
 
         logger.info(f"Sending template {self.message_type} to {addresses}")
-        return ses.send_email(
-            source=SMTP_FROM,
-            to=addresses,
-            subject=content["subject"],
-            text=content["text_content"],
-            html=content["html_content"],
-        )
+        if len(addresses) > 0 and addresses[0] is not None:
+            return ses.send_email(
+                source=SMTP_FROM,
+                to=addresses,
+                subject=content["subject"],
+                text=content["text_content"],
+                html=content["html_content"],
+            )


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
There was an issue loading Settings from the database. Fixes the settings load. 
There was another issue from the new FWD email notification when a subject is not passed in the context.
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
When registering a new user, an error would pop up saying a user already exists.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Tested locally to verify I could create a new user without the above error.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
