### PR TITLE
add categorization email field to settings endpoint

### DIFF
--- a/src/api/schemas/settings_schema.py
+++ b/src/api/schemas/settings_schema.py
@@ -33,3 +33,4 @@ class SettingsPostSchema(Schema):
 
     SES_FORWARD_EMAIL = fields.Email(allow_none=True)
     USER_NOTIFICATION_EMAIL = fields.Email(allow_none=True)
+    CATEGORIZATION_EMAIL = fields.Email(allow_none=True)

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -10,6 +10,7 @@ class Settings:
 
     SES_FORWARD_EMAIL = None
     USER_NOTIFICATION_EMAIL = None
+    CATEGORIZATION_EMAIL = None
 
     def __init__(self) -> None:
         """Init."""
@@ -41,4 +42,5 @@ class Settings:
         return {
             "SES_FORWARD_EMAIL": self.SES_FORWARD_EMAIL,
             "USER_NOTIFICATION_EMAIL": self.USER_NOTIFICATION_EMAIL,
+            "CATEGORIZATION_EMAIL": self.CATEGORIZATION_EMAIL,
         }

--- a/src/api/templates/emails/categorization_request.html
+++ b/src/api/templates/emails/categorization_request.html
@@ -1,0 +1,13 @@
+<body>
+  <h2>Domain Manager</h2>
+  <h4>Categorization Request</h4>
+  <p>Hello,</p>
+  <p>
+    The following domain has been requested to be categorized: {{ domain_name }}
+  </p>
+  <p>
+    Please submit this domain for categorization within the next 24 work hours.
+  </p>
+  <p>Thank you,</p>
+  <p>Domain Manager System</p>
+</body>

--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -35,6 +35,7 @@ from utils.categorization.categorize import (
     put_proxy_status,
 )
 from utils.decorators.auth import can_access_domain
+from utils.notifications import Notification
 from utils.users import get_users_group_ids
 from utils.validator import validate_data
 
@@ -531,6 +532,13 @@ class DomainCategorizeView(MethodView):
         resp, status_code = post_categorize_request(
             domain_id=domain_id, domain_name=domain["name"], requested_category=category
         )
+
+        email = Notification(
+            message_type="categorization_request",
+            context={"domain_name": domain["name"]},
+        )
+        email.send()
+
         return jsonify(resp), status_code
 
     def put(self, domain_id):

--- a/src/utils/notifications.py
+++ b/src/utils/notifications.py
@@ -80,6 +80,16 @@ class Notification:
                     "emails/user_confirmed.html", **context
                 ),
             },
+            "categorization_request": {
+                "send_to": "CategorizationEmail",
+                "subject": "[Domain Manager] Categorization Request",
+                "text_content": render_template_string(
+                    "emails/categorization_request.html", **context
+                ),
+                "html_content": render_template(
+                    "emails/categorization_request.html", **context
+                ),
+            },
         }.get(message_type)
 
     def get_to_addresses(self, content):
@@ -105,7 +115,8 @@ class Notification:
             addresses.append(email)
         elif content["send_to"] == "ForwardEmail":
             addresses.append(settings.to_dict()["SES_FORWARD_EMAIL"])
-
+        elif content["send_to"] == "CategorizationEmail":
+            addresses.append(settings.to_dict()["CATEGORIZATION_EMAIL"])
         return addresses
 
     def send(self):


### PR DESCRIPTION
Add the ability to set the categorization request email setting to the about page

## 🗣 Description ##
Be able to set up an email to receive notifications for incoming categorization requests

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->
Test ran locally

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - _eschew scope creep!_
- [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.
