### PR TITLE
feature: cpd-391 Categorization proxy refactor

### DIFF
--- a/src/api/schemas/categorization_schema.py
+++ b/src/api/schemas/categorization_schema.py
@@ -14,7 +14,9 @@ class CategorizationSchema(BaseSchema):
     domain_name = fields.Str()
     proxy = fields.Str()
     status = fields.Str(
-        validate=validate.OneOf(["new", "submitted", "verified", "rejected"])
+        validate=validate.OneOf(
+            ["new", "recategorize", "submitted", "verified", "burned"]
+        )
     )
     category = fields.Str(
         validate=validate.OneOf([category for category in CATEGORIES])

--- a/src/api/views/category_views.py
+++ b/src/api/views/category_views.py
@@ -37,11 +37,14 @@ class CategorizationsView(MethodView):
 
     def get(self):
         """Get all domain categorizations."""
-        status = request.args.get("status")
+        status = request.args.get("status").split(",")
         if not status:
             return jsonify({"message": "Please specify a status"}), 406
 
-        return jsonify(categorization_manager.all(params={"status": status})), 200
+        return (
+            jsonify(categorization_manager.all(params={"status": {"$in": status}})),
+            200,
+        )
 
 
 class CategorizationView(MethodView):

--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -557,13 +557,13 @@ class DomainCategorizeView(MethodView):
         if not status:
             return jsonify({"error": "Please specify a proxy status"}), 406
 
-        proxy_name = request.json.get("proxy")
+        category = request.json.get("category")
 
-        if not proxy_name:
-            return jsonify({"error": "Please specify a proxy name"}), 406
+        if not category:
+            return jsonify({"error": "Please specify a category"}), 406
 
         resp, status_code = put_proxy_status(
-            domain_id=domain_id, proxy_name=proxy_name, status=status
+            domain_id=domain_id, status=status, category=category
         )
 
         return jsonify(resp), status_code

--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -17,7 +17,13 @@ import requests
 
 # cisagov Libraries
 from api.config import STATIC_GEN_URL, WEBSITE_BUCKET, logger
-from api.manager import ApplicationManager, DomainManager, EmailManager, TemplateManager
+from api.manager import (
+    ApplicationManager,
+    CategorizationManager,
+    DomainManager,
+    EmailManager,
+    TemplateManager,
+)
 from api.schemas.domain_schema import DomainSchema, Record
 from utils.apex_records import contains_apex_record, is_apex_record
 from utils.aws import record_handler
@@ -39,6 +45,7 @@ from utils.notifications import Notification
 from utils.users import get_users_group_ids
 from utils.validator import validate_data
 
+categorization_manager = CategorizationManager()
 domain_manager = DomainManager()
 template_manager = TemplateManager()
 email_manager = EmailManager()
@@ -190,6 +197,8 @@ class DomainView(MethodView):
                 logger.info("Hosted zone doesn't exist.")
             else:
                 raise e
+
+        categorization_manager.delete(params={"domain_id": domain["_id"]})
 
         return jsonify(domain_manager.delete(domain["_id"]))
 

--- a/src/utils/categorization/categorize.py
+++ b/src/utils/categorization/categorize.py
@@ -41,11 +41,15 @@ def post_categorize_request(domain_id: str, domain_name: str, requested_category
     return {"success": "categorization request has been submitted"}, 200
 
 
-def put_proxy_status(domain_id: str, proxy_name: str, status: str):
+def put_proxy_status(domain_id: str, status: str, category: str):
     """Update proxy status for a domain."""
-    proxy = categorization_manager.get(
-        filter_data={"domain_id": domain_id, "proxy": proxy_name}, fields=["_id"]
+    proxies = categorization_manager.all(
+        params={"domain_id": domain_id}, fields=["_id"]
     )
-    categorization_manager.update(document_id=proxy["_id"], data={"status": status})
+
+    for proxy in proxies:
+        categorization_manager.update(
+            document_id=proxy["_id"], data={"status": status, "category": category}
+        )
 
     return {"success": "proxy status has been updated"}, 200


### PR DESCRIPTION
Add recategorization request capability and update domain proxy statuses

## 🗣 Description ##
Add "burned" and "recategorize" statuses to proxy status list
Refactor endpoint to be able to recategorize domain proxies that are not set to "new"
Delete categorizations for a domain on domain delete if they exist

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
successfully test ran locally

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - _eschew scope creep!_
- [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.
