### PR TITLE
Preload Gunicorn apps

### DIFF
--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -12,5 +12,5 @@ then
   python api/wsgi.py
 else
   echo "Serve using WSGI"
-  gunicorn --workers="$WORKERS" --bind=0.0.0.0:5000 --timeout=180 api.wsgi:app
+  gunicorn --workers="$WORKERS" --preload --bind=0.0.0.0:5000 --timeout=180 api.wsgi:app
 fi


### PR DESCRIPTION
otherwise the schedule is executed once per worker

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Sets Gunicorn to [preload](https://docs.gunicorn.org/en/stable/settings.html#preload-app).
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
Multiple schedulers are starting per worker, this forces one schedule to start in the master process, rather than one per worker process.
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
Tested locally to verify only one schedule is executed.
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.
