### PR TITLE
feature: cpd-433 delete domain proxies

### DIFF
--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -36,6 +36,7 @@ from utils.aws.site_handler import (
     verify_launch_records,
 )
 from utils.categorization.categorize import (
+    delete_domain_proxies,
     get_domain_proxies,
     post_categorize_request,
     put_proxy_status,
@@ -559,6 +560,11 @@ class DomainCategorizeView(MethodView):
             domain_id=domain_id, status=status, category=category
         )
 
+        return jsonify(resp), status_code
+
+    def delete(self, domain_id):
+        """Delete proxies for a domain."""
+        resp, status_code = delete_domain_proxies(domain_id)
         return jsonify(resp), status_code
 
 

--- a/src/utils/categorization/categorize.py
+++ b/src/utils/categorization/categorize.py
@@ -60,3 +60,15 @@ def put_proxy_status(domain_id: str, status: str, category: str):
         )
 
     return {"success": "proxy status has been updated"}, 200
+
+
+def delete_domain_proxies(domain_id: str):
+    """Delete all proxies for a domain."""
+    proxies = categorization_manager.all(
+        params={"domain_id": domain_id}, fields=["status"]
+    )
+    if not all(proxy["status"] == "new" for proxy in proxies):
+        return {"error": "only new proxy requests can be deleted"}, 400
+
+    categorization_manager.delete(params={"domain_id": domain_id})
+    return {"success": "domain proxies have been deleted"}, 200


### PR DESCRIPTION
Add delete domain proxies endpoint

## 🗣 Description ##
allow for the ability to delete proxy requests. This is only allowed if the proxy statuses are all set to "new"

## 💭 Motivation and context ##
Give the category manager the ability to reject category requests for domains that are not live or fit to be submitted for categorization.

## 🧪 Testing ##
succesfully tested locally

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - _eschew scope creep!_
- [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.
