### PR TITLE
feature: CPD-468 add categorization rejection message

### DIFF
--- a/src/api/schemas/domain_schema.py
+++ b/src/api/schemas/domain_schema.py
@@ -145,6 +145,7 @@ class DomainSchema(BaseSchema):
     is_generating_template = fields.Boolean(default=False)
     is_email_active = fields.Boolean()
     rejected_msg = fields.Str(allow_none=True)
+    was_burned = fields.Boolean(default=False)
     profile = fields.Dict()
     history = fields.List(fields.Nested(History))
     cloudfront = fields.Dict()

--- a/src/api/schemas/domain_schema.py
+++ b/src/api/schemas/domain_schema.py
@@ -145,7 +145,7 @@ class DomainSchema(BaseSchema):
     is_generating_template = fields.Boolean(default=False)
     is_email_active = fields.Boolean()
     rejected_msg = fields.Str(allow_none=True)
-    was_burned = fields.Boolean(default=False)
+    burned_date = DateTimeField()
     profile = fields.Dict()
     history = fields.List(fields.Nested(History))
     cloudfront = fields.Dict()

--- a/src/api/schemas/domain_schema.py
+++ b/src/api/schemas/domain_schema.py
@@ -144,6 +144,7 @@ class DomainSchema(BaseSchema):
     is_delaunching = fields.Boolean(default=False)
     is_generating_template = fields.Boolean(default=False)
     is_email_active = fields.Boolean()
+    rejected_msg = fields.Str(allow_none=True)
     profile = fields.Dict()
     history = fields.List(fields.Nested(History))
     cloudfront = fields.Dict()

--- a/src/api/views/category_views.py
+++ b/src/api/views/category_views.py
@@ -1,15 +1,19 @@
 """Category Views."""
+# Standard Python Libraries
+from datetime import datetime
+
 # Third-Party Libraries
 from flask import jsonify, request
 from flask.views import MethodView
 
 # cisagov Libraries
-from api.manager import CategorizationManager
+from api.manager import CategorizationManager, DomainManager
 from api.schemas.categorization_schema import CategorizationSchema
 from utils.categorization import CATEGORIES
 from utils.validator import validate_data
 
 categorization_manager = CategorizationManager()
+domain_manager = DomainManager()
 
 
 class CategoriesView(MethodView):
@@ -53,6 +57,17 @@ class CategorizationView(MethodView):
     def put(self, categorization_id):
         """Update categorization data."""
         put_data = validate_data(request.json, CategorizationSchema)
+
+        domain = domain_manager.get(
+            document_id=put_data["domain_id"], fields=["burned_date"]
+        )
+
+        if not domain["burned_date"] and put_data["status"] == "burned":
+            domain_manager.update(
+                document_id=put_data["domain_id"],
+                data={"burned_date": datetime.utcnow()},
+            )
+
         return jsonify(
             categorization_manager.update(document_id=categorization_id, data=put_data)
         )

--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -538,6 +538,9 @@ class DomainCategorizeView(MethodView):
 
         domain = domain_manager.get(document_id=domain_id)
 
+        if domain["rejected_msg"]:
+            domain_manager.update(document_id=domain_id, data={"rejected_msg": None})
+
         resp, status_code = post_categorize_request(
             domain_id=domain_id, domain_name=domain["name"], requested_category=category
         )

--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -565,6 +565,9 @@ class DomainCategorizeView(MethodView):
     def delete(self, domain_id):
         """Delete proxies for a domain."""
         resp, status_code = delete_domain_proxies(domain_id)
+        domain_manager.update(
+            document_id=domain_id, data={"rejected_msg": request.json.get("message")}
+        )
         return jsonify(resp), status_code
 
 


### PR DESCRIPTION
Add the capability to submit a message as to why a categorization request has been rejected.

## 🗣 Description ##
Keep track of domains that have been previously burned by saving the burned date if any one of it's proxies has been set to `burned`

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
Tested locally

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - _eschew scope creep!_
- [X] _All_ future TODOs are captured in issues, which are referenced
      in code comments.
- [X] All relevant type-of-change labels have been added.
- [X] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.
