### PR TITLE
fix: cpd-941 templates failing to download

### DIFF
--- a/src/api/views/domain_views.py
+++ b/src/api/views/domain_views.py
@@ -248,7 +248,7 @@ class DomainContentView(MethodView):
         return send_file(
             buffer,
             as_attachment=True,
-            attachment_filename=f"{domain['name']}.zip",
+            download_name=f"{domain['name']}.zip",
             mimetype="application/zip",
         )
 

--- a/src/api/views/template_views.py
+++ b/src/api/views/template_views.py
@@ -129,7 +129,7 @@ class TemplateContentView(MethodView):
         return send_file(
             buffer,
             as_attachment=True,
-            attachment_filename=f"{template['name']}.zip",
+            download_name=f"{template['name']}.zip",
             mimetype="application/zip",
         )
 


### PR DESCRIPTION
templates were failing to download due to the `send_file()` function from flask. the argument `attachment_filename=` has been changed to `download_name` in the latest version. 

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##
tested locally successfully

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.